### PR TITLE
Update payment.rst

### DIFF
--- a/modules/payment.rst
+++ b/modules/payment.rst
@@ -1,38 +1,12 @@
 Payment Modules
 =========
 
-
-Single Payment Service Modules
---------
-
-PayPal
-***********
-
 Bitcoin
 ***********
 
 **OpenNode_Bitcoin**
 
 https://github.com/rvelhote/opennode-magento
-
-Multi Payment Modules
---------
-
-Adyen
-***********
-
-https://github.com/Adyen/adyen-magento
-
-supports:
-
-* Credit Card
-* Local payment methods
-
-  * SEPA
-  * Boleto
-  * iDEAL
-  * Sofort
-* and more
 
 
 .. toctree::


### PR DESCRIPTION
I've removed empty categories and remove Adyen, which is the only payment gateway that actually removed support for magento1 is surely doesn't deserve any advertising. also the github repo was removed so the link was dead (another reason to remove it).