### PR TITLE
add MariaDB to glossary.rst

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -10,11 +10,14 @@ Glossary
     Composer
 
         A Tool to manage dependencies of a PHP project
-    
+
+    MariaDB
+        One of the possible databases OpenMage is compatible to. 
+
     Module
 
         The basic unit of distributable code, existing in one of two
         types: :term:`Pure Module`, or :term:`Extension Module`.
 
-    MySql
-        One of the possible Databases OpenMage is compatible to.
+    MySQL
+        One of the possible databases OpenMage is compatible to.


### PR DESCRIPTION
Suggesting adding MariaDB to the glossary. Also correcting spelling of MySQL. 

Was inspired by [this recent tweet](https://x.com/fballiano/status/1808125431360455070): 
_[#OpenMage](https://x.com/hashtag/OpenMage?src=hashtag_click) 20.10 is out, bringing copyable cells to backend grids, preliminary PHP 8.4 support, improved MariaDB compatibility and some bugfixes._